### PR TITLE
feat: add user profile and folder manager

### DIFF
--- a/backend/apps/documents/views/department_views.py
+++ b/backend/apps/documents/views/department_views.py
@@ -53,6 +53,10 @@ class FolderViewSet(viewsets.ModelViewSet):
                 queryset = queryset.filter(parent__isnull=True)
             else:
                 queryset = queryset.filter(parent_id=parent_id)
+
+        search = self.request.query_params.get('search')
+        if search:
+            queryset = queryset.filter(name__icontains=search)
         
         # If not admin, filter by user's department
         if not self.request.user.is_staff:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import DocumentDetail from '@/pages/DocumentDetail'
 import AdvancedSearch from '@/pages/AdvancedSearch'
 import Notifications from '@/pages/Notifications'
 import NotFound from '@/pages/NotFound'
+import Profile from '@/pages/Profile'
 import { ProtectedRoute } from '@/components/ProtectedRoute'
 import { AuthProvider } from '@/hooks/useAuth'
 
@@ -31,6 +32,7 @@ function App() {
             </Route>
             <Route path="search" element={<AdvancedSearch />} />
             <Route path="notifications" element={<Notifications />} />
+            <Route path="profile" element={<Profile />} />
           </Route>
           
           {/* Fallback routes */}

--- a/frontend/src/components/DepartmentSelector.tsx
+++ b/frontend/src/components/DepartmentSelector.tsx
@@ -8,6 +8,7 @@ interface DepartmentSelectorProps {
   onDepartmentChange: (departmentId: number | null) => void;
   onFolderChange: (folderId: number | null) => void;
   className?: string;
+  refreshKey?: number;
 }
 
 export default function DepartmentSelector({
@@ -15,7 +16,8 @@ export default function DepartmentSelector({
   selectedFolder,
   onDepartmentChange,
   onFolderChange,
-  className = ''
+  className = '',
+  refreshKey
 }: DepartmentSelectorProps) {
   // State
   const [departments, setDepartments] = useState<Department[]>([]);
@@ -50,16 +52,14 @@ export default function DepartmentSelector({
         setFolders([]);
         return;
       }
-      
+
       setIsLoading(true);
       setError('');
-      
+
       try {
         const foldersData = await getFolders(selectedDepartment);
         setFolders(foldersData);
-        
-        // If the currently selected folder doesn't belong to this department,
-        // reset the folder selection
+
         if (selectedFolder && !foldersData.some(f => f.id === selectedFolder)) {
           onFolderChange(null);
         }
@@ -70,9 +70,9 @@ export default function DepartmentSelector({
         setIsLoading(false);
       }
     };
-    
+
     fetchFolders();
-  }, [selectedDepartment, selectedFolder, onFolderChange]);
+  }, [selectedDepartment, selectedFolder, onFolderChange, refreshKey]);
   
   // Handler for department change
   const handleDepartmentChange = (e: React.ChangeEvent<HTMLSelectElement>) => {

--- a/frontend/src/components/DocumentUpload.tsx
+++ b/frontend/src/components/DocumentUpload.tsx
@@ -3,6 +3,7 @@ import { useDocumentUpload, DocumentFormData } from '@/hooks/useDocumentUpload'
 import { Tag, getTags } from '@/services/document.service'
 import DepartmentSelector from './DepartmentSelector'
 import { useLocation } from 'react-router-dom'
+import FolderManager from '@/components/FolderManager'
 
 interface DocumentUploadProps {
   onSuccess?: () => void
@@ -29,6 +30,8 @@ export default function DocumentUpload({ onSuccess, onCancel, isOpen }: Document
   const [selectedTags, setSelectedTags] = useState<number[]>([])
   const [selectedDepartment, setSelectedDepartment] = useState<number | null>(null)
   const [selectedFolder, setSelectedFolder] = useState<number | null>(null)
+  const [folderRefreshKey, setFolderRefreshKey] = useState(0)
+  const [isFolderManagerOpen, setIsFolderManagerOpen] = useState(false)
   const [fileName, setFileName] = useState<string>('')
   const [validationError, setValidationError] = useState<string>('')
   
@@ -227,6 +230,7 @@ export default function DocumentUpload({ onSuccess, onCancel, isOpen }: Document
   const displayError = validationError || uploadError
   
   return (
+    <>
     <div className={`fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity z-50 ${isOpen ? 'block' : 'hidden'} overflow-y-auto`}>
       <div className="flex min-h-full items-center justify-center p-4 text-center sm:p-0">
         <div className="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 w-full max-w-3xl mx-auto">
@@ -444,7 +448,15 @@ export default function DocumentUpload({ onSuccess, onCancel, isOpen }: Document
                     onDepartmentChange={(id) => setSelectedDepartment(id)}
                     onFolderChange={(id) => setSelectedFolder(id)}
                     className="space-y-2"
+                    refreshKey={folderRefreshKey}
                   />
+                  <button
+                    type="button"
+                    onClick={() => setIsFolderManagerOpen(true)}
+                    className="mt-2 inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-medium text-primary-700 shadow border border-primary-200 hover:bg-primary-50"
+                  >
+                    Ajouter un dossier
+                  </button>
                 </div>
               </div>
               
@@ -508,6 +520,17 @@ export default function DocumentUpload({ onSuccess, onCancel, isOpen }: Document
         </div>
       </div>
     </div>
+    <FolderManager
+      isOpen={isFolderManagerOpen}
+      onClose={() => setIsFolderManagerOpen(false)}
+      departmentId={selectedDepartment}
+      onFolderCreated={(folder) => {
+        setFolderRefreshKey((k) => k + 1)
+        setSelectedFolder(folder.id)
+        setFormData(prev => ({ ...prev, folder: folder.id }))
+      }}
+    />
+    </>
   )
 }
 

--- a/frontend/src/components/FolderManager.tsx
+++ b/frontend/src/components/FolderManager.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from 'react';
+import { Folder } from '@/types/department.types';
+import { getFolders, createFolder } from '@/services/department.service';
+
+interface FolderManagerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  departmentId: number | null;
+  onFolderCreated?: (folder: Folder) => void;
+}
+
+export default function FolderManager({ isOpen, onClose, departmentId, onFolderCreated }: FolderManagerProps) {
+  const [folders, setFolders] = useState<Folder[]>([]);
+  const [search, setSearch] = useState('');
+  const [name, setName] = useState('');
+  const [parent, setParent] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!isOpen || !departmentId) {
+      setFolders([]);
+      return;
+    }
+    const controller = new AbortController();
+    const loadFolders = async () => {
+      try {
+        const data = await getFolders(departmentId, undefined, search, { signal: controller.signal });
+        setFolders(data);
+      } catch (err) {
+        if (!(err instanceof DOMException)) {
+          console.error('Failed to load folders:', err);
+        }
+      }
+    };
+    loadFolders();
+    return () => controller.abort();
+  }, [isOpen, departmentId, search]);
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!departmentId || !name.trim()) return;
+    setIsLoading(true);
+    setError('');
+    try {
+      const folder = await createFolder({ name, department: departmentId, parent });
+      setName('');
+      setParent(null);
+      if (onFolderCreated) onFolderCreated(folder);
+    } catch (err: any) {
+      setError(err.message || 'Erreur lors de la création du dossier');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-30 flex items-center justify-center bg-black/30">
+      <div className="bg-white rounded-lg shadow-xl max-w-lg w-full p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-semibold text-gray-900">Gérer les dossiers</h3>
+          <button onClick={onClose} className="text-gray-500 hover:text-gray-700">✕</button>
+        </div>
+        {!departmentId ? (
+          <p className="text-sm text-gray-600">Sélectionnez d'abord un département.</p>
+        ) : (
+          <>
+            <div className="mb-4">
+              <input
+                type="text"
+                placeholder="Rechercher un dossier"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500"
+              />
+            </div>
+            <div className="max-h-40 overflow-y-auto border rounded-md mb-4">
+              <ul className="divide-y divide-gray-100">
+                {folders.map((f) => (
+                  <li key={f.id} className="p-2 text-sm text-gray-700">
+                    {f.path}
+                  </li>
+                ))}
+                {folders.length === 0 && (
+                  <li className="p-2 text-sm text-gray-500">Aucun dossier trouvé.</li>
+                )}
+              </ul>
+            </div>
+            <form onSubmit={handleCreate} className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700">Nom du dossier</label>
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  className="mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700">Dossier parent</label>
+                <select
+                  value={parent ?? ''}
+                  onChange={(e) => setParent(e.target.value ? Number(e.target.value) : null)}
+                  className="mt-1 w-full rounded-md border-gray-300 py-2 pl-3 pr-10 text-base focus:border-primary-500 focus:outline-none focus:ring-primary-500 sm:text-sm"
+                >
+                  <option value="">Aucun</option>
+                  {folders.map(f => (
+                    <option key={f.id} value={f.id}>{f.path}</option>
+                  ))}
+                </select>
+              </div>
+              {error && <p className="text-sm text-red-600">{error}</p>}
+              <div className="flex justify-end gap-2 pt-2 border-t border-gray-200">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="px-3 py-2 text-sm rounded-md border border-gray-300 bg-white text-gray-700 hover:bg-gray-50"
+                >
+                  Annuler
+                </button>
+                <button
+                  type="submit"
+                  disabled={isLoading}
+                  className="inline-flex items-center px-4 py-2 rounded-md bg-primary-600 text-white text-sm font-medium shadow-sm hover:bg-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:opacity-70"
+                >
+                  {isLoading ? 'Création...' : 'Créer'}
+                </button>
+              </div>
+            </form>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/pages/Documents.tsx
+++ b/frontend/src/pages/Documents.tsx
@@ -3,6 +3,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { useDocuments } from '@/hooks/useDocuments';
 import DocumentListItem from '@/components/DocumentListItem';
 import DepartmentSelector from '@/components/DepartmentSelector';
+import FolderManager from '@/components/FolderManager';
 
 export default function Documents() {
   const { isAuthenticated, user } = useAuth();
@@ -11,6 +12,8 @@ export default function Documents() {
   const [documentType, setDocumentType] = useState('');
   const [selectedDepartment, setSelectedDepartment] = useState<number | null>(null);
   const [selectedFolder, setSelectedFolder] = useState<number | null>(null);
+  const [isFolderManagerOpen, setIsFolderManagerOpen] = useState(false);
+  const [folderRefreshKey, setFolderRefreshKey] = useState(0);
 
   // Compose filters for useDocuments
   const filters = {
@@ -52,16 +55,28 @@ export default function Documents() {
       {/* Header and actions */}
       <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-8">
         <h2 className="text-3xl font-bold text-primary-700 tracking-tight">Documents</h2>
-        <button
-          type="button"
-          
-          className="inline-flex items-center gap-2 rounded-lg bg-primary-600 px-5 py-2 text-base font-semibold text-white shadow hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 transition"
-        >
-          <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-          </svg>
-          Télécharger un Document
-        </button>
+        <div className="flex gap-3">
+          <button
+            type="button"
+
+            className="inline-flex items-center gap-2 rounded-lg bg-primary-600 px-5 py-2 text-base font-semibold text-white shadow hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 transition"
+          >
+            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            </svg>
+            Télécharger un Document
+          </button>
+          <button
+            type="button"
+            onClick={() => setIsFolderManagerOpen(true)}
+            className="inline-flex items-center gap-2 rounded-lg bg-white px-5 py-2 text-base font-semibold text-primary-700 shadow border border-primary-200 hover:bg-primary-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 transition"
+          >
+            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+            Gérer les dossiers
+          </button>
+        </div>
       </div>
       <div className="bg-white/90 shadow-xl rounded-2xl border border-gray-100">
         <div className="p-6 space-y-6">
@@ -72,6 +87,7 @@ export default function Documents() {
             onDepartmentChange={setSelectedDepartment}
             onFolderChange={setSelectedFolder}
             className="mb-4"
+            refreshKey={folderRefreshKey}
           />
           {/* Search and filter */}
           <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
@@ -261,6 +277,15 @@ export default function Documents() {
           )}
         </div>
       </div>
+      <FolderManager
+        isOpen={isFolderManagerOpen}
+        onClose={() => setIsFolderManagerOpen(false)}
+        departmentId={selectedDepartment}
+        onFolderCreated={(folder) => {
+          setFolderRefreshKey((k) => k + 1);
+          setSelectedFolder(folder.id);
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,0 +1,60 @@
+import { useAuth } from '@/hooks/useAuth';
+
+export default function Profile() {
+  const { user } = useAuth();
+
+  if (!user) {
+    return (
+      <div className="text-center py-10">
+        <p className="text-gray-500">Vous devez être connecté pour voir votre profil.</p>
+        <a
+          href="/login"
+          className="mt-4 inline-flex items-center rounded-md bg-primary-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-primary-500"
+        >
+          Se connecter
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto bg-white shadow rounded-xl p-8">
+      <h2 className="text-2xl font-bold text-primary-700 mb-6">Profil de l'utilisateur</h2>
+      <dl className="divide-y divide-gray-200">
+        <div className="py-4 sm:grid sm:grid-cols-3 sm:gap-4">
+          <dt className="text-sm font-medium text-gray-500">Nom d'utilisateur</dt>
+          <dd className="mt-1 text-sm text-gray-900 sm:col-span-2">{user.username}</dd>
+        </div>
+        <div className="py-4 sm:grid sm:grid-cols-3 sm:gap-4">
+          <dt className="text-sm font-medium text-gray-500">Email</dt>
+          <dd className="mt-1 text-sm text-gray-900 sm:col-span-2">{user.email}</dd>
+        </div>
+        {user.first_name && (
+          <div className="py-4 sm:grid sm:grid-cols-3 sm:gap-4">
+            <dt className="text-sm font-medium text-gray-500">Prénom</dt>
+            <dd className="mt-1 text-sm text-gray-900 sm:col-span-2">{user.first_name}</dd>
+          </div>
+        )}
+        {user.last_name && (
+          <div className="py-4 sm:grid sm:grid-cols-3 sm:gap-4">
+            <dt className="text-sm font-medium text-gray-500">Nom</dt>
+            <dd className="mt-1 text-sm text-gray-900 sm:col-span-2">{user.last_name}</dd>
+          </div>
+        )}
+        {user.department && (
+          <div className="py-4 sm:grid sm:grid-cols-3 sm:gap-4">
+            <dt className="text-sm font-medium text-gray-500">Département</dt>
+            <dd className="mt-1 text-sm text-gray-900 sm:col-span-2">{user.department}</dd>
+          </div>
+        )}
+        {user.position && (
+          <div className="py-4 sm:grid sm:grid-cols-3 sm:gap-4">
+            <dt className="text-sm font-medium text-gray-500">Poste</dt>
+            <dd className="mt-1 text-sm text-gray-900 sm:col-span-2">{user.position}</dd>
+          </div>
+        )}
+      </dl>
+    </div>
+  );
+}
+

--- a/frontend/src/services/department.service.ts
+++ b/frontend/src/services/department.service.ts
@@ -3,6 +3,7 @@
  */
 import api from './api';
 import { Department, Folder } from '@/types/department.types';
+import { AxiosRequestConfig } from 'axios';
 
 /**
  * Get all departments
@@ -46,19 +47,28 @@ export const deleteDepartment = async (id: number): Promise<void> => {
 /**
  * Get all folders
  */
-export const getFolders = async (departmentId?: number, parentId?: number | null): Promise<Folder[]> => {
+export const getFolders = async (
+  departmentId?: number,
+  parentId?: number | null,
+  search?: string,
+  config?: AxiosRequestConfig
+): Promise<Folder[]> => {
   let url = '/folders/';
   const params: Record<string, string> = {};
-  
+
   if (departmentId !== undefined) {
     params.department = departmentId.toString();
   }
-  
+
   if (parentId !== undefined) {
     params.parent = parentId === null ? 'null' : parentId.toString();
   }
-  
-  const response = await api.get<Folder[]>(url, { params });
+
+  if (search) {
+    params.search = search;
+  }
+
+  const response = await api.get<Folder[]>(url, { params, ...(config || {}) });
   return response.data;
 };
 


### PR DESCRIPTION
## Summary
- add profile page and route for authenticated users
- introduce searchable folder manager with creation support in document workflows
- support folder name search on backend and client service

## Testing
- `python manage.py test` *(fails: Expected 'image_to_string' to have been called once...)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file...)*

------
https://chatgpt.com/codex/tasks/task_e_689153e2d244832b9840d1ff5d426ca1