### PR TITLE
Fix document editing and enhance OCR

### DIFF
--- a/backend/apps/notifications/signals.py
+++ b/backend/apps/notifications/signals.py
@@ -35,7 +35,8 @@ def create_document_notifications(sender, instance, created, **kwargs):
     
     else:
         # Document was updated
-        if instance.ocr_processed and instance.tracker.has_changed('ocr_processed'):
+        # Notify when OCR processing completes
+        if instance.is_ocr_processed:
             # OCR processing completed
             Notification.objects.create(
                 user=instance.uploaded_by,

--- a/frontend/src/components/DocumentUpload.tsx
+++ b/frontend/src/components/DocumentUpload.tsx
@@ -4,6 +4,7 @@ import { Tag, getTags } from '@/services/document.service'
 import DepartmentSelector from './DepartmentSelector'
 import { useLocation } from 'react-router-dom'
 import FolderManager from '@/components/FolderManager'
+import { DocumentType, documentTypeLabels } from '@/types/document.types'
 
 interface DocumentUploadProps {
   onSuccess?: () => void
@@ -325,13 +326,11 @@ export default function DocumentUpload({ onSuccess, onCancel, isOpen }: Document
                         className="block w-full rounded-md border-0 py-2 px-3 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-primary-600 sm:text-sm sm:leading-6 transition-colors"
                       >
                         <option value="">Sélectionner le type de document</option>
-                        <option value="invoice">Facture</option>
-                        <option value="bill_of_lading">Connaissement</option>
-                        <option value="transfer_request">Demande de transfert</option>
-                        <option value="contract">Contrat</option>
-                        <option value="report">Rapport</option>
-                        <option value="memo">Mémo</option>
-                        <option value="other">Autre</option>
+                        {Object.values(DocumentType).map(type => (
+                          <option key={type} value={type}>
+                            {documentTypeLabels[type]}
+                          </option>
+                        ))}
                       </select>
                     </div>
                   </div>

--- a/frontend/src/components/EditDocumentModal.tsx
+++ b/frontend/src/components/EditDocumentModal.tsx
@@ -3,6 +3,7 @@ import { Dialog, Transition } from '@headlessui/react'
 import { Document, updateDocument, getTags } from '@/services/document.service'
 import { Department, Folder } from '@/types/department.types'
 import { getDepartments, getFolders } from '@/services/department.service'
+import { DocumentType, documentTypeLabels } from '@/types/document.types'
 import { useToast } from '@/contexts/ToastContext'
 
 interface EditDocumentModalProps {
@@ -25,8 +26,8 @@ export default function EditDocumentModal({
     document_type: '',
     reference_number: '',
     date: '',
-    department_id: '',
-    folder_id: '',
+    department: '',
+    folder: '',
     tag_ids: [] as number[]
   })
   const [departments, setDepartments] = useState<Department[]>([])
@@ -67,8 +68,8 @@ export default function EditDocumentModal({
         document_type: cleanDocType,
         reference_number: document.reference_number || '',
         date: document.date || '',
-        department_id: document.department_id?.toString() || '',
-        folder_id: document.folder_id?.toString() || '',
+        department: (document.department as any)?.toString() || '',
+        folder: (document.folder as any)?.toString() || '',
         tag_ids: tagIds
       })
     }
@@ -98,9 +99,9 @@ export default function EditDocumentModal({
   // Load folders when department changes
   useEffect(() => {
     const loadFolders = async () => {
-      if (formData.department_id) {
+      if (formData.department) {
         try {
-          const foldersResponse = await getFolders(parseInt(formData.department_id))
+          const foldersResponse = await getFolders(parseInt(formData.department))
           setFolders(foldersResponse)
         } catch (error) {
           console.error('Error loading folders:', error)
@@ -112,7 +113,7 @@ export default function EditDocumentModal({
     }
 
     loadFolders()
-  }, [formData.department_id])
+  }, [formData.department])
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     const { name, value } = e.target
@@ -203,11 +204,11 @@ export default function EditDocumentModal({
       if (formData.reference_number.trim()) updateData.reference_number = formData.reference_number.trim();
       if (formData.date) updateData.date = formData.date;
       
-      // Handle department_id - convert to number or null
-      updateData.department_id = formData.department_id ? parseInt(formData.department_id) : null;
-      
-      // Handle folder_id - convert to number or null
-      updateData.folder_id = formData.folder_id ? parseInt(formData.folder_id) : null;
+      // Handle department - convert to number or null
+      updateData.department = formData.department ? parseInt(formData.department) : null;
+
+      // Handle folder - convert to number or null
+      updateData.folder = formData.folder ? parseInt(formData.folder) : null;
       
       // Always include tag_ids as a clean array of numbers
       updateData.tag_ids = [];
@@ -364,28 +365,26 @@ export default function EditDocumentModal({
                       id="document_type"
                       value={formData.document_type}
                       onChange={(e) => {
-                        // Special handler for document_type to ensure clean values
-                        const value = e.target.value;
+                        const value = e.target.value
                         setFormData(prev => ({
                           ...prev,
                           document_type: value
-                        }));
-                        // Clear error when user selects a value
+                        }))
                         if (errors.document_type) {
-                          setErrors(prev => ({ ...prev, document_type: '' }));
+                          setErrors(prev => ({ ...prev, document_type: '' }))
                         }
-                        console.log('Selected document_type:', value);
+                        console.log('Selected document_type:', value)
                       }}
                       className={`mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 ${
                         errors.document_type ? 'border-red-300' : ''
                       }`}
                     >
                       <option value="">Sélectionner un type</option>
-                      <option value="pdf">PDF</option>
-                      <option value="docx">Word</option>
-                      <option value="xlsx">Excel</option>
-                      <option value="image">Image</option>
-                      <option value="other">Autre</option>
+                      {Object.values(DocumentType).map((type) => (
+                        <option key={type} value={type}>
+                          {documentTypeLabels[type]}
+                        </option>
+                      ))}
                     </select>
                     {errors.document_type && (
                       <p className="mt-1 text-sm text-red-600">{errors.document_type}</p>
@@ -424,13 +423,13 @@ export default function EditDocumentModal({
 
                   {/* Department */}
                   <div>
-                    <label htmlFor="department_id" className="block text-sm font-medium text-gray-700">
+                    <label htmlFor="department" className="block text-sm font-medium text-gray-700">
                       Département
                     </label>
                     <select
-                      name="department_id"
-                      id="department_id"
-                      value={formData.department_id}
+                      name="department"
+                      id="department"
+                      value={formData.department}
                       onChange={handleInputChange}
                       className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500"
                     >
@@ -444,15 +443,15 @@ export default function EditDocumentModal({
                   </div>
 
                   {/* Folder */}
-                  {formData.department_id && (
+                  {formData.department && (
                     <div>
-                      <label htmlFor="folder_id" className="block text-sm font-medium text-gray-700">
+                      <label htmlFor="folder" className="block text-sm font-medium text-gray-700">
                         Dossier
                       </label>
                       <select
-                        name="folder_id"
-                        id="folder_id"
-                        value={formData.folder_id}
+                        name="folder"
+                        id="folder"
+                        value={formData.folder}
                         onChange={handleInputChange}
                         className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500"
                       >

--- a/frontend/src/hooks/useDocumentUpload.tsx
+++ b/frontend/src/hooks/useDocumentUpload.tsx
@@ -73,6 +73,8 @@ export const useDocumentUpload = () => {
         reference_number: documentData.reference_number?.trim() || '',
         date: documentData.date,
         tag_ids: documentData.tag_ids || [],
+        department: documentData.department ?? null,
+        folder: documentData.folder ?? null,
       };
 
       console.log('Preparing document upload with data:', {

--- a/frontend/src/services/document.service.ts
+++ b/frontend/src/services/document.service.ts
@@ -13,10 +13,8 @@ export interface Document {
   id?: number;
   title: string;
   document_type: string;
-  department_id?: number | null;
-  department?: Department;
-  folder_id?: number | null;
-  folder?: Folder;
+  department?: number | Department | null;
+  folder?: number | Folder | null;
   file?: File | string;
   file_name?: string;
   file_size?: number;
@@ -415,34 +413,18 @@ export const updateDocument = async (id: number, document: Partial<Document>): P
     else if (key === 'date' && value) {
       formData.append(key, value.toString());
     }
-    // Handle department_id and folder_id - allow null values
-    else if ((key === 'department_id' || key === 'folder_id')) {
+    // Handle department and folder - allow null values
+    else if (key === 'department' || key === 'folder') {
       if (value === null) {
         formData.append(key, '');
       } else {
         formData.append(key, value.toString());
       }
     }
-    // Handle document_type - ensure it's sent as a clean value that matches exactly what backend expects
+    // Handle document_type - send value directly
     else if (key === 'document_type') {
-      // Map frontend values to backend expected values if needed
-      // This mapping ensures we send exactly what the backend expects
-      const documentTypeMap: Record<string, string> = {
-        'PDF': 'pdf',
-        'Word': 'docx',
-        'Excel': 'xlsx',
-        'Image': 'image',
-        'Other': 'other'
-      };
-      
-      // Clean up the document type and convert to lowercase for consistent comparison
-      const cleanDocumentType = value.toString().replace(/[\\'"]/g, '').trim();
-      
-      // Use the mapped value if it exists, otherwise use lowercase version of the clean value
-      const finalDocumentType = documentTypeMap[cleanDocumentType] || cleanDocumentType.toLowerCase();
-      
-      formData.append(key, finalDocumentType);
-      console.log(`Adding document_type: "${finalDocumentType}" (original: "${value}")`);
+      formData.append(key, value.toString());
+      console.log(`Adding document_type: "${value}"`);
     }
     // Handle all other fields
     else {

--- a/frontend/src/types/document.types.ts
+++ b/frontend/src/types/document.types.ts
@@ -18,10 +18,8 @@ export interface Document {
   id: number;
   title: string;
   document_type: string;
-  department_id?: number | null;
-  department?: Department;
-  folder_id?: number | null;
-  folder?: Folder;
+  department?: number | Department | null;
+  folder?: number | Folder | null;
   file: string | File;
   file_name?: string;
   file_size?: number;


### PR DESCRIPTION
## Summary
- enable editing documents with proper type and dossier fields
- wire up tesseract OCR and notifications
- include department & folder metadata when uploading

## Testing
- `npm test` *(fails: Missing script: "test")*
- `python manage.py test apps.ai`


------
https://chatgpt.com/codex/tasks/task_e_68929d806250832b87ac4584a6949e23