### PR TITLE
fix: keep notification dropdown open on interaction

### DIFF
--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -126,7 +126,9 @@ export default function NotificationBell() {
     if (!isOpen) return null;
     
     return createPortal(
-      <div 
+      <div
+        onMouseDown={(e) => e.stopPropagation()}
+        onClick={(e) => e.stopPropagation()}
         className="fixed z-[9999] mt-2 w-80 origin-top-right rounded-md bg-white py-1 shadow-xl ring-1 ring-black ring-opacity-5 focus:outline-none"
         style={{
           top: `${dropdownPosition.top}px`,


### PR DESCRIPTION
## Summary
- prevent notification dropdown from closing when clicking its actions by stopping mouse events from propagating

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68935b8e1948832baca73adf34d0c6d0